### PR TITLE
Fixes jsonschema bounds, use sha256, use standard script line 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "flasgger" %}
 {% set version = "0.9.3" %}
-{% set md5 = "fea9435ab3df7fe23e7462b12bfbe4ce" %}
 
 package:
   name: {{ name|lower }}
@@ -9,12 +8,12 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  md5: {{ md5 }}
+  sha256: fe62d086ca341f71072fd21c2d4f993b6958ce47ee8f0a4ae716e7c901afeb21
 
 build:
   noarch: python
-  number: 0
-  script: python -m pip install --no-deps --ignore-installed .
+  number: 1
+  script: "{{ PYTHON }} -m pip install . -vv"
 
 requirements:
   build:
@@ -23,7 +22,7 @@ requirements:
     - setuptools
   run:
     - flask >=0.10
-    - jsonschema >=2.5.1,<3.0.0
+    - jsonschema >=2.5.1,<3.0.0a0
     - mistune
     - python
     - pyyaml >=3.0


### PR DESCRIPTION
Fix jsonschema upper-bound
Prefer sha256 to md5 for checksum
Use standard script line

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
